### PR TITLE
Always Random Wildcards

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -478,10 +478,12 @@ def worker():
             for i in range(image_number):
                 if disable_seed_increment:
                     task_seed = seed % (constants.MAX_SEED + 1)
+                    wild_seed = (seed + i) % (constants.MAX_SEED + 1)  # always increment seed for wildcards
                 else:
                     task_seed = (seed + i) % (constants.MAX_SEED + 1)  # randint is inclusive, % is not
+                    wild_seed = task_seed
 
-                task_rng = random.Random(task_seed)  # may bind to inpaint noise in the future
+                task_rng = random.Random(wild_seed)  # may bind to inpaint noise in the future
                 task_prompt = apply_wildcards(prompt, task_rng, i, read_wildcards_in_order)
                 task_prompt = apply_arrays(task_prompt, i)
                 task_negative_prompt = apply_wildcards(negative_prompt, task_rng, i, read_wildcards_in_order)


### PR DESCRIPTION
In async-worker.py, introduce a new variable, "wild_seed" to ensure that wildcards are always chosen randomly, even when seed increment is disabled.